### PR TITLE
fix(chartjs-advanced): use actual radial gradient in doughnut example

### DIFF
--- a/plugins/chartjs-expert/skills/chartjs-advanced/examples/gradient-backgrounds.html
+++ b/plugins/chartjs-expert/skills/chartjs-advanced/examples/gradient-backgrounds.html
@@ -190,17 +190,39 @@
     });
 
     // 4. Radial Gradient (Doughnut)
+    const doughnutColors = [
+      { inner: 'rgba(255, 99, 132, 1)', outer: 'rgba(255, 99, 132, 0.3)' },
+      { inner: 'rgba(54, 162, 235, 1)', outer: 'rgba(54, 162, 235, 0.3)' },
+      { inner: 'rgba(255, 206, 86, 1)', outer: 'rgba(255, 206, 86, 0.3)' }
+    ];
+
     new Chart(document.getElementById('radialGradient'), {
       type: 'doughnut',
       data: {
         labels: ['Red', 'Blue', 'Yellow'],
         datasets: [{
           data: [300, 150, 100],
-          backgroundColor: [
-            'rgba(255, 99, 132, 0.8)',
-            'rgba(54, 162, 235, 0.8)',
-            'rgba(255, 206, 86, 0.8)'
-          ],
+          backgroundColor: function(context) {
+            const chart = context.chart;
+            const { ctx, chartArea } = chart;
+            if (!chartArea) return null;
+
+            const centerX = (chartArea.left + chartArea.right) / 2;
+            const centerY = (chartArea.top + chartArea.bottom) / 2;
+            const radius = Math.min(
+              chartArea.right - chartArea.left,
+              chartArea.bottom - chartArea.top
+            ) / 2;
+
+            const colors = doughnutColors[context.dataIndex];
+            const gradient = ctx.createRadialGradient(
+              centerX, centerY, 0,
+              centerX, centerY, radius
+            );
+            gradient.addColorStop(0, colors.inner);
+            gradient.addColorStop(1, colors.outer);
+            return gradient;
+          },
           borderWidth: 2,
           borderColor: '#fff'
         }]


### PR DESCRIPTION
## Summary

- Doughnut chart example was titled "Radial Gradient" but used solid colors
- Now uses scriptable `backgroundColor` with `context.dataIndex` to apply per-segment radial gradients
- Each segment fades from solid (center) to 30% opacity (outer edge)

## Test plan

- [ ] Open `gradient-backgrounds.html` in browser
- [ ] Verify doughnut segments show radial gradient effect (solid center, faded edge)
- [ ] Verify all other gradient examples still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)