### PR TITLE
docs: populate CHANGELOG.md for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,45 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-12-25
+
+### Added
+
+#### Skills
+
+- 10 Chart.js v4.5.1 skills providing comprehensive domain coverage:
+  - `chartjs-overview` - Getting started, installation, and core concepts
+  - `chartjs-chart-types` - Line, bar, pie, doughnut, radar, polar area, bubble, scatter charts
+  - `chartjs-configuration` - Options, responsive design, and chart customization
+  - `chartjs-axes` - Scales, ticks, grid lines, and axis configuration
+  - `chartjs-animations` - Animation options, easing, and transitions
+  - `chartjs-tooltips` - Tooltip configuration, callbacks, and custom rendering
+  - `chartjs-plugins` - Plugin system, built-in plugins, and custom plugin development
+  - `chartjs-integrations` - Framework integration with Rails 8, Hotwire, Stimulus, React, Vue
+  - `chartjs-developers` - API reference, lifecycle, and advanced patterns
+  - `chartjs-advanced` - Performance optimization, tree-shaking, and complex use cases
+
+#### Commands
+
+- `/chartjs:component` - Interactive chart code generation with customizable options
+
+#### Agents
+
+- `chartjs-expert` - Proactive agent for Chart.js assistance and guidance
+
+#### Documentation
+
+- 21 working HTML examples demonstrating Chart.js patterns and best practices
+- 20 reference documents with deep-dive technical content
+- Comprehensive Rails 8 integration coverage (Hotwire, Stimulus, Turbo)
+
+#### CI/CD
+
+- GitHub Actions workflows for quality assurance:
+  - markdownlint for Markdown files
+  - htmlhint for HTML examples
+  - yamllint for YAML configuration
+  - lychee for broken link detection
+  - actionlint for workflow validation
+  - Claude-powered component validation


### PR DESCRIPTION
## Description

Populate the empty CHANGELOG.md file with documented v0.1.0 features using [Keep a Changelog](https://keepachangelog.com/) format.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Documentation (README.md, CLAUDE.md, CHANGELOG.md)

## Motivation and Context

Per the official Claude Code plugin reference: "Document changes in a CHANGELOG.md file." The CHANGELOG.md was empty beyond the header, and the plugin is feature-complete.

Fixes #16

## How Has This Been Tested?

**Test Configuration**:
- Claude Code version: Claude Opus 4.5
- OS: macOS

**Test Steps**:
1. Verified actual counts: 10 skills, 21 HTML examples, 20 reference documents
2. Ran `markdownlint CHANGELOG.md` - passed

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated relevant documentation (README.md or skill docs)
- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint '**/*.md'` and fixed all issues

## Additional Notes

Updated the reference document count from 18 (as stated in the issue) to the actual count of 20.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)