### PR TITLE
docs: pin Chart.js CDN to v4.5.1 in example files

### DIFF
--- a/skills/chartjs-overview/examples/basic-bar-chart.html
+++ b/skills/chartjs-overview/examples/basic-bar-chart.html
@@ -76,7 +76,7 @@
   </div>
 
   <!-- Load Chart.js from CDN -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
 
   <script>
     // Example 1: Simple Bar Chart

--- a/skills/chartjs-overview/examples/multi-dataset-line.html
+++ b/skills/chartjs-overview/examples/multi-dataset-line.html
@@ -103,7 +103,7 @@
   </div>
 
   <!-- Load Chart.js from CDN -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
 
   <script>
     // Example 1: Year-over-Year Comparison


### PR DESCRIPTION
## Description

Pin unpinned CDN links to Chart.js v4.5.1 to prevent silent breakage when future Chart.js versions are released with breaking changes.

## Type of Change

- [x] Documentation update (improvements to README or skill docs)

## Component(s) Affected

- [x] Examples (HTML/JS samples in `examples/` folders)

## Motivation and Context

Examples using unpinned CDN links (`chart.js"`) will silently break when Chart.js v5.0 is released with breaking changes. This fix ensures all examples use the pinned version `chart.js@4.5.1` for consistency and stability.

Fixes #17

## How Has This Been Tested?

**Test Configuration**:
- OS: macOS

**Test Steps**:
1. Verified no unpinned links remain: `rg 'jsdelivr.net/npm/chart\.js"' --type html`
2. Ran htmlhint: `npx htmlhint 'skills/**/examples/*.html'` - no errors

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Linting

- [x] I have run `npx htmlhint 'skills/**/examples/*.html'` on HTML examples

### Chart.js Compatibility

- [x] Changes align with Chart.js v4.5.1 documentation

## Additional Notes

Only 2 files had unpinned CDN links - the other 15 HTML example files were already correctly pinned to v4.5.1.

Files updated:
- `skills/chartjs-overview/examples/basic-bar-chart.html`
- `skills/chartjs-overview/examples/multi-dataset-line.html`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)