### PR TITLE
chore(deps): use commit SHAs instead of tag object SHAs

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       # The workflow logs contain all information needed for analysis
 
       - name: Analyze failure with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -44,7 +44,7 @@ jobs:
           pip install yamllint==1.37.1
 
       - name: Review PR with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_commit_signing: true

--- a/.github/workflows/component-validation.yml
+++ b/.github/workflows/component-validation.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Validate plugin components
         if: steps.changed-files.outputs.has_changes == 'true'
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         id: validate
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/semantic-labeler.yml
+++ b/.github/workflows/semantic-labeler.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
 
       - name: Label issue with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -129,7 +129,7 @@ jobs:
           fetch-depth: 1
 
       - name: Label PR with Claude
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Sync labels
         # Uses GITHUB_TOKEN automatically (provided by GitHub Actions)
         # Dry-run on PRs to preview changes, apply on push to main
-        uses: EndBug/label-sync@7753e99e1e64188c24d7deede343c5a63e7c0d39 # v2.3.3
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yml
           delete-other-labels: false

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run actionlint with reviewdog
-        uses: reviewdog/action-actionlint@c50cc86378c76976bc8d9c67e0f12327f85c323f # v1.69.1
+        uses: reviewdog/action-actionlint@83e4ed25b168066ad8f62f5afbb29ebd8641d982 # v1.69.1
         with:
           reporter: github-pr-review
           fail_level: error

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Generate maintenance report
-        uses: anthropics/claude-code-action@098e6be5fa94fd7f5b98b1f1a9b874cb9269e583 # v1.0.29
+        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Description

Update GitHub Action references to use commit SHAs instead of annotated tag object SHAs for consistency with other projects in the organization.

## Type of Change

- [x] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Other (please specify): GitHub workflow files

## Motivation and Context

During a cross-project GitHub Actions audit, it was discovered that this repository was using annotated tag object SHAs instead of commit SHAs for some GitHub Actions. While both resolve to the same code, commit SHAs are the standard convention.

**Actions updated:**
| Action | Old (tag object SHA) | New (commit SHA) |
|--------|---------------------|------------------|
| anthropics/claude-code-action@v1.0.29 | `098e6be5...` | `1b8ee3b9...` |
| EndBug/label-sync@v2.3.3 | `7753e99e...` | `52074158...` |
| reviewdog/action-actionlint@v1.69.1 | `c50cc863...` | `83e4ed25...` |

## How Has This Been Tested?

**Test Configuration**:
- N/A - this is a SHA consistency fix, not a functional change

**Test Steps**:
1. Both SHA types resolve to the same commit
2. CI workflows will validate the actions work correctly

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Linting

- [x] I have run `actionlint` on workflow files (if modified)

## Additional Notes

This change aligns this repository with the SHA pinning convention used in:
- bootstrap-expert
- cc-plugin-eval
- plugin-dev
- rails-expert
- requirements-expert

---

🤖 Generated with [Claude Code](https://claude.ai/code)