### PR TITLE
chore(ci): reduce workflow dependencies with CLI alternatives

### DIFF
--- a/.github/workflows/html-lint.yml
+++ b/.github/workflows/html-lint.yml
@@ -32,10 +32,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          node-version: '20'
-
       - name: Run HTMLHint
         run: npx htmlhint 'skills/**/examples/*.html'

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -32,8 +32,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install yamllint
-        run: pip install yamllint==1.37.1
-
       - name: Run yamllint
-        run: yamllint -c .yamllint.yml .github/ .claude-plugin/
+        run: pipx run yamllint==1.37.1 -c .yamllint.yml .github/ .claude-plugin/


### PR DESCRIPTION
## Description

Reduce GitHub Actions dependencies by using CLI alternatives that don't require separate installation or version management.

## Type of Change

- [x] Configuration change (changes to .markdownlint.json, plugin.json, etc.)

## Component(s) Affected

- [x] Other (please specify): GitHub workflow files

## Motivation and Context

Third-party GitHub Actions require ongoing maintenance (Dependabot updates, SHA pinning). Where possible, using CLI tools that are pre-installed on runners or run via `npx`/`pipx` reduces this burden.

**Changes made:**

| Workflow | Before | After | Benefit |
|----------|--------|-------|---------|
| `html-lint.yml` | `actions/setup-node` + `npx` | Just `npx` | Ubuntu runners have Node.js 20+ pre-installed |
| `yaml-lint.yml` | `pip install yamllint` | `pipx run yamllint` | Single command, no separate install step |

This follows the pattern already established in `markdownlint.yml`, which uses `npx markdownlint-cli2` without `setup-node`.

## How Has This Been Tested?

**Test Configuration**:
- Both linters will run on this PR via CI

**Test Steps**:
1. Verify HTML linting works without explicit Node.js setup
2. Verify YAML linting works with pipx

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or errors

### Linting

- [x] I have run `actionlint` on workflow files (if modified)

## Additional Notes

This is part of a broader effort to reduce dependency maintenance overhead. Future candidates for similar treatment:
- `lycheeverse/lychee-action` → direct lychee binary
- `EndBug/label-sync` → `npx github-label-sync`
- `reviewdog/action-actionlint` → direct actionlint binary

---

🤖 Generated with [Claude Code](https://claude.ai/code)